### PR TITLE
fix(evidence): escape string in data-tip to prevent xss

### DIFF
--- a/src/components/attachment/index.js
+++ b/src/components/attachment/index.js
@@ -8,6 +8,7 @@ import { ReactComponent as Document } from '../../assets/primary-document.svg'
 import { ReactComponent as Image } from '../../assets/image.svg'
 import { ReactComponent as Link } from '../../assets/link.svg'
 import { ReactComponent as Video } from '../../assets/video.svg'
+import escapeString from '../../utils/escape-strings'
 
 import isImage from 'is-image'
 import isTextPath from 'is-text-path'
@@ -39,7 +40,7 @@ const Attachment = ({ URI, title, description }) => {
           className="Attachment"
         >
           <Component
-            data-tip={`<h2 class='Attachment-title'>${title}</h2><p class='Attachment-description'>${description}</p>`}
+            data-tip={`<h2 class='Attachment-title'>${escapeString(title)}</h2><p class='Attachment-description'>${escapeString(description)}</p>`}
           />
         </a>
       ) : (
@@ -47,7 +48,7 @@ const Attachment = ({ URI, title, description }) => {
           <Component
             className="Attachment-component-link"
             onClick={() => setModal(!open)}
-            data-tip={`<h2 class='Attachment-title'>${title}</h2><p class='Attachment-description'>${description}</p>`}
+            data-tip={`<h2 class='Attachment-title'>${escapeString(title)}</h2><p class='Attachment-description'>${escapeString(description)}</p>`}
           />
           <Modal
             open={open}

--- a/src/components/new-arbitrable-tx/index.js
+++ b/src/components/new-arbitrable-tx/index.js
@@ -250,7 +250,7 @@ const NewArbitrableTx = ({ formArbitrabletx, accounts, balance }) => {
                 }}
               />
               <div className="FileInput-filename">
-                {values.file ? values.file.name : 'filename...'}
+                {values.file ? values.file.name : '-- Upload --'}
               </div>
             </div>
             {errors.file && (

--- a/src/components/new-invoice-arbitrable-tx/index.js
+++ b/src/components/new-invoice-arbitrable-tx/index.js
@@ -232,7 +232,7 @@ const NewInvoiceArbitrableTx = ({ formArbitrabletx, accounts, balance }) => {
                 }}
               />
               <div className="FileInput-filename">
-                {values.file ? values.file.name : 'filename...'}
+                {values.file ? values.file.name : '-- Upload --'}
               </div>
             </div>
             {errors.file && (

--- a/src/utils/escape-strings.js
+++ b/src/utils/escape-strings.js
@@ -1,0 +1,12 @@
+export default (_dangerousString) => {
+  const map = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#x27;',
+      "/": '&#x2F;',
+  };
+  const reg = /[&<>"'/]/ig;
+  return _dangerousString.replace(reg, (match)=>(map[match]));
+}


### PR DESCRIPTION
- Escape strings given to hover tool tip to prevent xss.

Closes #25 