### PR TITLE
refactor(payments): allow for receiver to claim payment

### DIFF
--- a/src/components/arbitrable-tx-cards/index.js
+++ b/src/components/arbitrable-tx-cards/index.js
@@ -45,7 +45,7 @@ const ArbitrableTxCards = ({ arbitrabletxs }) => (
                 {shortAddress(arbitrabletx[arbitrabletx.otherParty])}
               </div>
               <div className="ArbitrableTxCards-cards-section-header-party">
-                {arbitrabletx.otherParty}
+                {arbitrabletx.otherParty === 'sender' ? 'receiver' : 'sender'}
               </div>
             </div>
             <div className="ArbitrableTxCards-cards-section-h2">
@@ -137,11 +137,15 @@ const ArbitrableTxCards = ({ arbitrabletxs }) => (
                 </div>
               )}
               {arbitrabletx.detailsStatus ===
-                statusArbitrableTxConstants.DISPUTE_RESOLVED && (
+                statusArbitrableTxConstants.DISPUTE_RESOLVED && (arbitrabletx.disputeId === '0' ? (
+                <div className="ArbitrableTxCards-cards-section-footer-completed">
+                  Payment Complete
+                </div>
+              ) : (
                 <div className="ArbitrableTxCards-cards-section-footer-completed">
                   Dispute Resolved
                 </div>
-              )}
+              ))}
             </div>
           </section>
         ))}

--- a/src/components/arbitrable-tx-cards/index.js
+++ b/src/components/arbitrable-tx-cards/index.js
@@ -139,7 +139,7 @@ const ArbitrableTxCards = ({ arbitrabletxs }) => (
               {arbitrabletx.detailsStatus ===
                 statusArbitrableTxConstants.DISPUTE_RESOLVED && (arbitrabletx.disputeId === '0' ? (
                 <div className="ArbitrableTxCards-cards-section-footer-completed">
-                  Payment Complete
+                  Payment Completed
                 </div>
               ) : (
                 <div className="ArbitrableTxCards-cards-section-footer-completed">

--- a/src/sagas/arbitrable-transaction.js
+++ b/src/sagas/arbitrable-transaction.js
@@ -103,8 +103,6 @@ function* fetchMetaEvidence({ type, payload: { metaEvidenceIPFSHash } }) {
     ...Object.entries(metaEvidenceDecoded.aliases).map(([a, b]) => ({ [b]: a }))
   )
 
-  console.log(parties)
-
   return yield put(
     action(arbitrabletxActions.arbitrabletx.RESUMEFORM, {
       arbitrabletxResumeForm: {
@@ -172,7 +170,6 @@ function* fetchArbitrabletxs() {
   if (!accounts[0]) throw new Error(errorConstants.ETH_NO_ACCOUNTS)
 
   let multipleArbitrableTransactionEth = {}
-  let arbitrableTransactionIds = []
   let arbitrableTransactions = []
 
   for (let arbitrableContract of ARBITRABLE_ADDRESSES) {

--- a/src/utils/render-status-arbitrable-tx-switch.js
+++ b/src/utils/render-status-arbitrable-tx-switch.js
@@ -384,9 +384,9 @@ export default (
                 ) : (
                   <>
                     {arbitrabletx.data.ruling === '0' && (arbitrabletx.data.disputeId !== "0" ? (
-                      <p>No Ruling</p>
+                      <p>Juros refused to arbitrate.</p>
                     ):(
-                      <p>Payment Complete</p>
+                      <p>Payment Completed</p>
                     ))}
                     {arbitrabletx.data.ruling === '1' && (
                       <p>Sender won the dispute.</p>

--- a/src/utils/render-status-arbitrable-tx-switch.js
+++ b/src/utils/render-status-arbitrable-tx-switch.js
@@ -44,7 +44,7 @@ export default (
             />
           ) : (
             <>
-              {accounts[0] === arbitrabletx.data.sender &&
+              {(accounts[0] === arbitrabletx.data.sender || accounts[0] === arbitrabletx.data.receiver) &&
               Date.now() - arbitrabletx.data.lastInteraction * 1000 >=
                 arbitrabletx.data.timeoutPayment * 1000 ? (
                 <ResumeArbitrableTx
@@ -74,7 +74,7 @@ export default (
                               <ClipLoader size={20} color={'#fff'} />
                             </span>
                           )}{' '}
-                          Execute Payment
+                          {accounts[0] === arbitrabletx.data.sender ? 'Send' : 'Claim'} Payment
                         </Button>
                       </Form>
                     )}
@@ -383,10 +383,11 @@ export default (
                   </>
                 ) : (
                   <>
-                    {console.log(arbitrabletx)}
-                    {arbitrabletx.data.ruling === '0' && (
-                      <p>Jurors refused to vote or payment timed out.</p>
-                    )}
+                    {arbitrabletx.data.ruling === '0' && (arbitrabletx.data.disputeId !== "0" ? (
+                      <p>No Ruling</p>
+                    ):(
+                      <p>Payment Complete</p>
+                    ))}
                     {arbitrabletx.data.ruling === '1' && (
                       <p>Sender won the dispute.</p>
                     )}


### PR DESCRIPTION
- Allow for Receiver to claim the payout in the event of a timeout.
- Swap use of Sender/Receiver in the homepage cards.
- Add Payment Complete as the message for resolved payments with no disputes.

* There is an edge case where disputeID 0 will show as a payment instead of a dispute in some of the copy. I didn't see any other obvious way to tell if a dispute had been raised as uninitialized disputeId in the smart contract returns as 0 and after the payment is executed it changes status from NoDispute to Resolved. Should only affect testing and copy changes do not obscure anything.