### PR TITLE
refactor(settlements): use number input instead of slider

### DIFF
--- a/src/components/agreement_fully/index.js
+++ b/src/components/agreement_fully/index.js
@@ -29,18 +29,11 @@ const AgreementFully = ({
   const setPercentByAmount = amount => {
     if (amount <= arbitrabletx.data.amount) {
       setAmount(amount)
-      setPercent((amount * 100) / arbitrabletx.data.amount)
+      setPercent((amount * 100) / arbitrabletx.data.originalAmount)
     } else {
       setAmount(arbitrabletx.data.amount)
-      setPercent(100)
+      setPercent((arbitrabletx.data.amount * 100) / arbitrabletx.data.originalAmount)
     }
-  }
-
-  const setAmountByPercent = percent => {
-    setPercent(percent)
-    setAmount(
-      1 * Number((percent / 100) * arbitrabletx.data.amount).toFixed(18)
-    )
   }
 
   return (
@@ -57,20 +50,11 @@ const AgreementFully = ({
           Waive Part of the Payment
         </h2>
         <p className="AgreementFully-modal-description">
-          Propose a settlement by giving a percentage of the payment to the
-          other party.
+          Propose a settlement by giving up part of the payment to the other party.
           <br />A dispute can still be raised over the remaining balance.
         </p>
-        <Slider
-          min={0}
-          max={100}
-          labels={{ 0: '0%', 100: '100%' }}
-          value={percent}
-          onChange={setAmountByPercent}
-        />
-        <p className="AgreementFully-modal-offer">
-          You are waiving{' '}
-          <span style={{ color: '#009aff' }}>{percent.toFixed(6)}%</span>.
+        <p className="AgreementFully-modal-description">
+          Current Payment Balance: {arbitrabletx.data.amount} ETH
         </p>
         <div className="AgreementFully-modal-buttons">
           <div className="AgreementFully-modal-buttons-pay-reimburse">
@@ -84,6 +68,10 @@ const AgreementFully = ({
               onChangeAmount={setPercentByAmount}
             />
           </div>
+          <p className="AgreementFully-modal-offer">
+            Remaining balance will be {' '}
+            <span style={{ color: '#009aff' }}>{(arbitrabletx.data.amount - amount).toFixed(2)} ETH</span>
+          </p>
         </div>
         <div className="divider" />
         <div style={{ textAlign: 'center' }}>

--- a/src/components/agreement_fully/index.js
+++ b/src/components/agreement_fully/index.js
@@ -26,13 +26,12 @@ const AgreementFully = ({
   const [open, setModal] = useState(false)
   const [percent, setPercent] = useState(0) // set Percent
   const [amount, setAmount] = useState(0) // set Percent
-  const setPercentByAmount = amount => {
+  const setAmountFromInput = amount => {
     if (amount <= arbitrabletx.data.amount) {
-      setAmount(amount)
-      setPercent((amount * 100) / arbitrabletx.data.originalAmount)
+      if (amount < 0) setAmount(0)
+      else setAmount(amount)
     } else {
       setAmount(arbitrabletx.data.amount)
-      setPercent((arbitrabletx.data.amount * 100) / arbitrabletx.data.originalAmount)
     }
   }
 
@@ -65,7 +64,7 @@ const AgreementFully = ({
               amount={amount}
               amountMax={arbitrabletx.data.amount}
               id={arbitrabletx.data.id}
-              onChangeAmount={setPercentByAmount}
+              onChangeAmount={setAmountFromInput}
             />
           </div>
           <p className="AgreementFully-modal-offer">

--- a/src/components/new-arbitrable-tx/index.js
+++ b/src/components/new-arbitrable-tx/index.js
@@ -133,7 +133,7 @@ const NewArbitrableTx = ({ formArbitrabletx, accounts, balance }) => {
               className="FormNewArbitrableTx-error FormNewArbitrableTx-error-receiver"
             />
             <div className="FormNewArbitrableTx-help FormNewArbitrableTx-help-receiver">
-              Enter the ETH address of the counterparty to this agreement.
+              Enter the ETH address of the counterparty to this agreement. Make sure to use an address this party controls <span style={{fontWeight: 800}}>(Do not use an exchange address)</span>.
             </div>
             <label
               htmlFor="timeout"

--- a/src/components/new-invoice-arbitrable-tx/index.js
+++ b/src/components/new-invoice-arbitrable-tx/index.js
@@ -110,7 +110,7 @@ const NewInvoiceArbitrableTx = ({ formArbitrabletx, accounts }) => {
               Eg. Marketing Services Agreement with John
             </div>
             <div className="FormNewInvoiceArbitrableTx-help FormNewInvoiceArbitrableTx-help-receiver">
-              Enter the ETH address of the counterparty to this agreement.
+              Enter the ETH address of the counterparty to this agreement. Make sure to use an address this party controls (Do not use an exchange address).
             </div>
             <label
               htmlFor="timeout"


### PR DESCRIPTION
Closes #45 
Closes #42 

- Slider removed in favor or a number input to reduce confusion about percentages.
- Warning added to not use exchange address