### PR TITLE
feat: add check for max file size

### DIFF
--- a/src/components/new-arbitrable-tx/index.js
+++ b/src/components/new-arbitrable-tx/index.js
@@ -71,8 +71,10 @@ const NewArbitrableTx = ({ formArbitrabletx, accounts, balance, tokens, template
             if (values.description.length < 1)
               errors.description =
                 'Description is required.'
-            if (showFileUpload && values.file.size > 1024 * 1024 * 4)
+            if (showFileUpload && values.file.size > 1024 * 1024 * 4) {
               errors.file = 'The file is too big. The maximum size is 4MB.'
+              alert('The file is too big. The maximum size is 4MB.')
+            }
             for (let extraDetailsKeys of Object.keys(template.optionalInputs)) {
               if (!values.extraData[extraDetailsKeys])
                 errors[extraDetailsKeys] = 'Field required'

--- a/src/components/new-arbitrable-tx/index.js
+++ b/src/components/new-arbitrable-tx/index.js
@@ -71,10 +71,8 @@ const NewArbitrableTx = ({ formArbitrabletx, accounts, balance, tokens, template
             if (values.description.length < 1)
               errors.description =
                 'Description is required.'
-            if (showFileUpload && values.file.size > 1024 * 1024 * 4) {
+            if (showFileUpload && values.file.size > 1024 * 1024 * 4)
               errors.file = 'The file is too big. The maximum size is 4MB.'
-              alert('The file is too big. The maximum size is 4MB.')
-            }
             for (let extraDetailsKeys of Object.keys(template.optionalInputs)) {
               if (!values.extraData[extraDetailsKeys])
                 errors[extraDetailsKeys] = 'Field required'

--- a/src/components/new-arbitrable-tx/index.js
+++ b/src/components/new-arbitrable-tx/index.js
@@ -71,8 +71,8 @@ const NewArbitrableTx = ({ formArbitrabletx, accounts, balance, tokens, template
             if (values.description.length < 1)
               errors.description =
                 'Description is required.'
-            if (showFileUpload && values.file.size > 5000000)
-              errors.file = 'The file is too big. The maximum size is 5MB.'
+            if (showFileUpload && values.file.size > 1024 * 1024 * 4)
+              errors.file = 'The file is too big. The maximum size is 4MB.'
             for (let extraDetailsKeys of Object.keys(template.optionalInputs)) {
               if (!values.extraData[extraDetailsKeys])
                 errors[extraDetailsKeys] = 'Field required'

--- a/src/components/new-evidence-arbitrable-tx/index.js
+++ b/src/components/new-evidence-arbitrable-tx/index.js
@@ -23,8 +23,10 @@ const NewEvidenceArbitrableTx = ({ submitEvidence, arbitrable, id }) => (
         if (values.description.length > 255)
           errors.description =
             'The description is too long. The maximum length is 255 characters.'
-        if (values.file.size > 1024 * 1024 * 4)
+        if (values.file.size > 1024 * 1024 * 4) {
           errors.file = 'The file is too big. The maximum size is 4MB.'
+          alert('The file is too big. The maximum size is 4MB.')
+        }
         return errors
       }}
       // eslint-disable-next-line react/jsx-no-bind

--- a/src/components/new-evidence-arbitrable-tx/index.js
+++ b/src/components/new-evidence-arbitrable-tx/index.js
@@ -23,10 +23,8 @@ const NewEvidenceArbitrableTx = ({ submitEvidence, arbitrable, id }) => (
         if (values.description.length > 255)
           errors.description =
             'The description is too long. The maximum length is 255 characters.'
-        if (values.file.size > 1024 * 1024 * 4) {
+        if (values.file.size > 1024 * 1024 * 4)
           errors.file = 'The file is too big. The maximum size is 4MB.'
-          alert('The file is too big. The maximum size is 4MB.')
-        }
         return errors
       }}
       // eslint-disable-next-line react/jsx-no-bind

--- a/src/components/new-evidence-arbitrable-tx/index.js
+++ b/src/components/new-evidence-arbitrable-tx/index.js
@@ -23,8 +23,8 @@ const NewEvidenceArbitrableTx = ({ submitEvidence, arbitrable, id }) => (
         if (values.description.length > 255)
           errors.description =
             'The description is too long. The maximum length is 255 characters.'
-        if (values.file.size > 5000000)
-          errors.file = 'The file is too big. The maximum size is 5MB.'
+        if (values.file.size > 1024 * 1024 * 4)
+          errors.file = 'The file is too big. The maximum size is 4MB.'
         return errors
       }}
       // eslint-disable-next-line react/jsx-no-bind

--- a/src/components/new-invoice-arbitrable-tx/index.js
+++ b/src/components/new-invoice-arbitrable-tx/index.js
@@ -66,10 +66,8 @@ const NewInvoiceArbitrableTx = ({ formArbitrabletx, accounts }) => {
           if (values.description.length > 1000000)
             errors.description =
               'The description is too long. The maximum length is 1,000,000 characters.'
-          if (values.file.size > 1024 * 1024 * 4) {
+          if (values.file.size > 1024 * 1024 * 4)
             errors.file = 'The file is too big. The maximum size is 4MB.'
-            alert('The file is too big. The maximum size is 4MB.')  
-          }
           return errors
         }}
         // eslint-disable-next-line react/jsx-no-bind

--- a/src/components/new-invoice-arbitrable-tx/index.js
+++ b/src/components/new-invoice-arbitrable-tx/index.js
@@ -66,8 +66,8 @@ const NewInvoiceArbitrableTx = ({ formArbitrabletx, accounts }) => {
           if (values.description.length > 1000000)
             errors.description =
               'The description is too long. The maximum length is 1,000,000 characters.'
-          if (values.file.size > 5000000)
-            errors.file = 'The file is too big. The maximum size is 5MB.'
+          if (values.file.size > 1024 * 1024 * 4)
+            errors.file = 'The file is too big. The maximum size is 4MB.'
           return errors
         }}
         // eslint-disable-next-line react/jsx-no-bind

--- a/src/components/new-invoice-arbitrable-tx/index.js
+++ b/src/components/new-invoice-arbitrable-tx/index.js
@@ -66,8 +66,10 @@ const NewInvoiceArbitrableTx = ({ formArbitrabletx, accounts }) => {
           if (values.description.length > 1000000)
             errors.description =
               'The description is too long. The maximum length is 1,000,000 characters.'
-          if (values.file.size > 1024 * 1024 * 4)
+          if (values.file.size > 1024 * 1024 * 4) {
             errors.file = 'The file is too big. The maximum size is 4MB.'
+            alert('The file is too big. The maximum size is 4MB.')  
+          }
           return errors
         }}
         // eslint-disable-next-line react/jsx-no-bind

--- a/src/sagas/arbitrable-transaction.js
+++ b/src/sagas/arbitrable-transaction.js
@@ -59,6 +59,12 @@ function* formArbitrabletx({ type, payload: { arbitrabletxForm } }) {
   }
 
   if (arbitrabletxForm.file) {
+    // The backend cannot handle files larger than 4MB
+    const maxSizeInBytes = 4 * 1024 * 1024;
+    if (arbitrabletxForm.file.size > maxSizeInBytes) {
+      alert('File is too large. Maximum size is 4MB.');
+      return;
+    }
     const data = yield call(readFile, arbitrabletxForm.file.dataURL)
     // Upload the meta-evidence then return an ipfs hash
     const fileIpfsHash = yield call(

--- a/src/sagas/arbitrable-transaction.js
+++ b/src/sagas/arbitrable-transaction.js
@@ -59,12 +59,6 @@ function* formArbitrabletx({ type, payload: { arbitrabletxForm } }) {
   }
 
   if (arbitrabletxForm.file) {
-    // The backend cannot handle files larger than 4MB
-    const maxSizeInBytes = 4 * 1024 * 1024;
-    if (arbitrabletxForm.file.size > maxSizeInBytes) {
-      alert('File is too large. Maximum size is 4MB.');
-      return;
-    }
     const data = yield call(readFile, arbitrabletxForm.file.dataURL)
     // Upload the meta-evidence then return an ipfs hash
     const fileIpfsHash = yield call(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating file size validation in three components to enforce a maximum file size of 4MB instead of 5MB. 

### Detailed summary
- In `src/components/new-evidence-arbitrable-tx/index.js`, updated file size check from 5MB to 4MB.
- In `src/components/new-invoice-arbitrable-tx/index.js`, updated file size check from 5MB to 4MB.
- In `src/components/new-arbitrable-tx/index.js`, updated file size check from 5MB to 4MB.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->